### PR TITLE
Add methods for converting vector tiles, layers, and features to GeoJSON

### DIFF
--- a/lib/vectortile.js
+++ b/lib/vectortile.js
@@ -41,3 +41,15 @@ VectorTile.prototype.readLayer = function() {
     buffer.pos = end;
     return layer;
 };
+
+// Returns a dictionary of layers as individual GeoJSON feature collections, keyed by layer name
+VectorTile.prototype.toGeoJSON = function () {
+    var json = {};
+    var layerNames = Object.keys(this.layers);
+
+    for (var n=0; n < layerNames.length; n++) {
+        json[layerNames[n]] = this.layers[layerNames[n]].toGeoJSON();
+    }
+
+    return json;
+};

--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -14,6 +14,7 @@ function VectorTileFeature(buffer, end, extent, keys, values) {
     // Public
     this._extent = extent;
     this._type = 0;
+    this._keys = keys;
 
     // Private
     this._buffer = buffer;
@@ -140,4 +141,46 @@ VectorTileFeature.prototype.bbox = function() {
     }
 
     return [x1, y1, x2, y2];
+};
+
+VectorTileFeature.prototype.toGeoJSON = function () {
+    var geojson = {
+        type: 'Feature',
+        geometry: {},
+        properties: {}
+    };
+
+    for (var k=0; k < this._keys.length; k++) {
+        var key = this._keys[k];
+        geojson.properties[key] = this[key];
+    }
+
+    geojson.geometry.coordinates = this.loadGeometry();
+    for (var r=0; r < geojson.geometry.coordinates.length; r++) {
+        var ring = geojson.geometry.coordinates[r];
+        for (var c=0; c < ring.length; c++) {
+            ring[c] = [
+                ring[c].x,
+                ring[c].y
+            ];
+        }
+    }
+
+    if (this._type == VectorTileFeature.Point) {
+        geojson.geometry.type = 'Point';
+    }
+    else if (this._type == VectorTileFeature.LineString) {
+        if (geojson.geometry.coordinates.length == 1) {
+            geojson.geometry.coordinates = geojson.geometry.coordinates[0];
+            geojson.geometry.type = 'LineString';
+        }
+        else {
+            geojson.geometry.type = 'MultiLineString';
+        }
+    }
+    else if (this._type == VectorTileFeature.Polygon) {
+        geojson.geometry.type = 'Polygon';
+    }
+
+    return geojson;
 };

--- a/lib/vectortilelayer.js
+++ b/lib/vectortilelayer.js
@@ -90,3 +90,16 @@ VectorTileLayer.prototype.feature = function(i) {
     var end = this._buffer.readVarint() + this._buffer.pos;
     return new VectorTileFeature(this._buffer, end, this.extent, this._keys, this._values);
 };
+
+VectorTileLayer.prototype.toGeoJSON = function () {
+    var geojson = {
+        type: 'FeatureCollection',
+        features: []
+    };
+
+    for (var f=0; f < this.length; f++) {
+        geojson.features.push(this.feature(f).toGeoJSON());
+    }
+
+    return geojson;
+};

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -37,4 +37,27 @@ describe('parsing vector tiles', function() {
         // Check line geometry
         assert.deepEqual(tile.layers.road.feature(656).loadGeometry(), [ [ { x: 1988, y: 306 }, { x: 1808, y: 321 }, { x: 1506, y: 347 } ] ]);
     });
+
+    it('should convert to GeoJSON', function() {
+        var tile = new VectorTile(data);
+        var geojson = tile.toGeoJSON();
+
+        assert.deepEqual(Object.keys(geojson), [
+            'landuse', 'waterway', 'water', 'barrier_line', 'building',
+            'landuse_overlay', 'tunnel', 'road', 'bridge', 'place_label',
+            'water_label', 'poi_label', 'road_label', 'waterway_label' ]);
+
+        assert.equal(geojson.poi_label.features.length, 558);
+
+        var park = geojson.poi_label.features[11];
+
+        assert.equal(park.properties.name, 'Mauerpark');
+        assert.equal(park.properties.type, 'Park');
+
+        // Check point geometry
+        assert.deepEqual(park.geometry.coordinates, [ [ [3898, 1731] ] ]);
+
+        // Check line geometry
+        assert.deepEqual(geojson.road.features[656].geometry.coordinates, [ [1988, 306], [1808, 321], [1506, 347] ]);
+    });
 });


### PR DESCRIPTION
Note that VectorTile.toGeoJSON() is a bit of a misnomer since it returns an object with individual GeoJSON collections for each layer (could just be toJSON() instead).

Other than that, anything you'd want done differently here? The built-in API is concise but it's nice to have GeoJSON for compatibility.