### PR TITLE
limit z to 16 to avoid overflow, fix issue https://github.com/mapbox/mapbox-gl-js/issues/1205

### DIFF
--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -123,6 +123,7 @@ VectorTileFeature.prototype.bbox = function() {
 };
 
 VectorTileFeature.prototype.toGeoJSON = function(x, y, z) {
+    var z = Math.min(z, 16);
     var size = this.extent * Math.pow(2, z),
         x0 = this.extent * x,
         y0 = this.extent * y,


### PR DESCRIPTION
This is the only solution I came up, if we want to continue using the Math library.



