### PR TITLE
Mention public 'properties' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ An object that contains the data for a single feature.
 
 - **type** (`Number`) &mdash; type of the feature (also see `VectorTileFeature.types`)
 - **extent** (`Number`) &mdash; feature extent size
+- **properties** (`Object`) &mdash; object literal with feature properties
 
 #### Methods
 


### PR DESCRIPTION
`VectorTileFeature` has a public `properties`  property, which was missing from the API documentation.