### PR TITLE
Fix coordinates for MultiPoints in toGeoJSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4.1"
+  - 4
 script:
   - npm test
   - npm run cov

--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -147,7 +147,7 @@ VectorTileFeature.prototype.toGeoJSON = function(x, y, z) {
     if (type === 'Point' && coords.length === 1) {
         coords = coords[0][0];
     } else if (type === 'Point') {
-        coords = coords[0];
+        coords = coords.map(function (c) { return c[0]; });
         type = 'MultiPoint';
     } else if (type === 'LineString' && coords.length === 1) {
         coords = coords[0];

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -142,11 +142,23 @@ test('parsing vector tiles', function(t) {
         }
 
         // https://github.com/mapbox/vector-tile-spec/issues/30
-        t.equal(geoJSONFromFixture("singleton-multi-point").geometry.type, 'Point');
-        t.equal(geoJSONFromFixture("singleton-multi-line").geometry.type, 'LineString');
+        t.ok(approximateDeepEqual(geoJSONFromFixture("singleton-multi-point").geometry, {
+            type: 'Point',
+            coordinates: [1, 2]
+        }, 1e-1));
+        t.ok(approximateDeepEqual(geoJSONFromFixture("singleton-multi-line").geometry, {
+            type: 'LineString',
+            coordinates: [[1, 2], [3, 4]]
+        }, 1e-1));
 
-        t.equal(geoJSONFromFixture("multi-point").geometry.type, 'MultiPoint');
-        t.equal(geoJSONFromFixture("multi-line").geometry.type, 'MultiLineString');
+        t.ok(approximateDeepEqual(geoJSONFromFixture("multi-point").geometry, {
+            type: 'MultiPoint',
+            coordinates: [[1, 2], [3, 4]]
+        }, 1e-1));
+        t.ok(approximateDeepEqual(geoJSONFromFixture("multi-line").geometry, {
+            type: 'MultiLineString',
+            coordinates: [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+        }, 1e-1));
 
         t.end();
     })

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -5,6 +5,32 @@ var test = require('tape'),
     VectorTileLayer = require('..').VectorTileLayer,
     VectorTileFeature = require('..').VectorTileFeature;
 
+function approximateDeepEqual(a, b, epsilon) {
+    epsilon = epsilon || 1e-6;
+
+    if (typeof a !== typeof b)
+        return false;
+    if (typeof a === 'number')
+        return Math.abs(a - b) < epsilon;
+    if (a === null || typeof a !== 'object')
+        return a === b;
+
+    var ka = Object.keys(a);
+    var kb = Object.keys(b);
+
+    if (ka.length != kb.length)
+        return false;
+
+    ka.sort();
+    kb.sort();
+
+    for (var i = 0; i < ka.length; i++)
+        if (ka[i] != kb[i] || !approximateDeepEqual(a[ka[i]], b[ka[i]], epsilon))
+            return false;
+
+    return true;
+}
+
 test('parsing vector tiles', function(t) {
     var data = fs.readFileSync(__dirname + '/fixtures/14-8801-5371.vector.pbf');
 
@@ -59,58 +85,56 @@ test('parsing vector tiles', function(t) {
     t.test('toGeoJSON', function(t) {
         var tile = new VectorTile(new Protobuf(data));
 
-        function close(actual, expected) {
-            t.equal(actual.length, expected.length);
-            for (var i = 0; i < actual.length; i++) {
-                if (actual[i].length) {
-                    close(actual[i], expected[i]);
-                } else {
-                    t.ok(Math.abs(actual[i] - expected[i]) < 1e-6);
-                }
+        t.ok(approximateDeepEqual(tile.layers.poi_label.feature(11).toGeoJSON(8801, 5371, 14), {
+            type: 'Feature',
+            id: 3000003150561,
+            properties: {
+                localrank: 1,
+                maki: 'park',
+                name: 'Mauerpark',
+                name_de: 'Mauerpark',
+                name_en: 'Mauerpark',
+                name_es: 'Mauerpark',
+                name_fr: 'Mauerpark',
+                osm_id: 3000003150561,
+                ref: '',
+                scalerank: 2,
+                type: 'Park'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [13.402258157730103, 52.54398925380624]
             }
-        }
+        }));
 
-        var point = tile.layers.poi_label.feature(11).toGeoJSON(8801, 5371, 14);
-        t.deepEqual(point.type, 'Feature');
-        t.deepEqual(point.id, 3000003150561);
-        t.deepEqual(point.properties, {
-            localrank: 1,
-            maki: 'park',
-            name: 'Mauerpark',
-            name_de: 'Mauerpark',
-            name_en: 'Mauerpark',
-            name_es: 'Mauerpark',
-            name_fr: 'Mauerpark',
-            osm_id: 3000003150561,
-            ref: '',
-            scalerank: 2,
-            type: 'Park'
-        });
-        t.deepEqual(point.geometry.type, 'Point');
-        close(point.geometry.coordinates, [13.402258157730103, 52.54398925380624]);
+        t.ok(approximateDeepEqual(tile.layers.bridge.feature(0).toGeoJSON(8801, 5371, 14), {
+            type: 'Feature',
+            id: 238162948,
+            properties: {
+                class: 'service',
+                oneway: 0,
+                osm_id: 238162948,
+                type: 'service'
+            },
+            geometry: {
+                type: 'LineString',
+                coordinates: [[13.399457931518555, 52.546334844036416], [13.399441838264465, 52.546504478525016]]
+            }
+        }));
 
-        var line = tile.layers.bridge.feature(0).toGeoJSON(8801, 5371, 14);
-        t.deepEqual(line.type, 'Feature');
-        t.deepEqual(line.properties, {
-            class: 'service',
-            oneway: 0,
-            osm_id: 238162948,
-            type: 'service'
-        });
-        t.deepEqual(line.geometry.type, 'LineString');
-        close(line.geometry.coordinates,
-            [[13.399457931518555, 52.546334844036416], [13.399441838264465, 52.546504478525016]]);
-
-        var poly = tile.layers.building.feature(0).toGeoJSON(8801, 5371, 14);
-        t.deepEqual(poly.type, 'Feature');
-        t.deepEqual(poly.properties, {
-            osm_id: 1000267229912
-        });
-        t.deepEqual(poly.geometry.type, 'Polygon');
-        close(poly.geometry.coordinates,
-            [[[13.392285704612732, 52.54974045706258], [13.392264246940613, 52.549737195107554],
-                [13.392248153686523, 52.549737195107554], [13.392248153686523, 52.54974045706258],
-                [13.392285704612732, 52.54974045706258]]]);
+        t.ok(approximateDeepEqual(tile.layers.building.feature(0).toGeoJSON(8801, 5371, 14), {
+            type: 'Feature',
+            id: 1000267229912,
+            properties: {
+                osm_id: 1000267229912
+            },
+            geometry: {
+                type: 'Polygon',
+                coordinates: [[[13.392285704612732, 52.54974045706258], [13.392264246940613, 52.549737195107554],
+                    [13.392248153686523, 52.549737195107554], [13.392248153686523, 52.54974045706258],
+                    [13.392285704612732, 52.54974045706258]]]
+            }
+        }));
 
         function geoJSONFromFixture(name) {
             var tile = new VectorTile(new Protobuf(fs.readFileSync(__dirname + '/fixtures/' + name + '.pbf')));


### PR DESCRIPTION
Previously, only the first point was included and the array nesting was wrong.