### PR TITLE
Make VectorTileFeature#id a public property

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ An object that contains the data for a single feature.
 
 - **type** (`Number`) &mdash; type of the feature (also see `VectorTileFeature.types`)
 - **extent** (`Number`) &mdash; feature extent size
+- **id** (`Number`) &mdash; feature identifier, if present
 - **properties** (`Object`) &mdash; object literal with feature properties
 
 #### Methods

--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -20,7 +20,7 @@ function VectorTileFeature(pbf, end, extent, keys, values) {
 }
 
 function readFeature(tag, feature, pbf) {
-    if (tag == 1) feature._id = pbf.readVarint();
+    if (tag == 1) feature.id = pbf.readVarint();
     else if (tag == 2) readTag(pbf, feature);
     else if (tag == 3) feature.type = pbf.readVarint();
     else if (tag == 4) feature._geometry = pbf.pos;
@@ -185,8 +185,8 @@ VectorTileFeature.prototype.toGeoJSON = function(x, y, z) {
         properties: this.properties
     };
 
-    if ('_id' in this) {
-        result.id = this._id;
+    if ('id' in this) {
+        result.id = this.id;
     }
 
     return result;

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -58,6 +58,8 @@ test('parsing vector tiles', function(t) {
             var park = tile.layers.poi_label.feature(1e9);
         }, 'throws on reading a feature out of bounds');
 
+        t.equal(park.id, 3000003150561);
+
         t.equal(park.properties.name, 'Mauerpark');
         t.equal(park.properties.type, 'Park');
 


### PR DESCRIPTION
Fixes #43.

This implementation will be a breaking change for code that relies on the undocumented `_id` property. I know of one such use [in mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js/blob/92a1c72b6e804e4a86fe94f3d53c8614c314f725/js/util/vectortile_to_geojson.js#L13-L14), which we can easily fix when we upgrade the vector-tile-js dependency there.

We could make this fully compatible by adding a getter for `_id` which returns `id`, but I don't think it's worth it. Anyone have a different opinion?

cc @mourner @drnextgis