### PR TITLE
Update to mapbox namespace and update dev dependency of mapnik

### DIFF
--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Point = require('point-geometry');
+var Point = require('@mapbox/point-geometry');
 
 module.exports = VectorTileFeature;
 

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "vector-tile",
+  "name": "@mapbox/vector-tile",
   "description": "Parses vector tiles",
   "repository": "https://github.com/mapbox/vector-tile-js.git",
   "version": "1.3.0",
   "license": "BSD-3-Clause",
   "main": "index.js",
   "dependencies": {
-    "point-geometry": "0.0.0"
+    "@mapbox/point-geometry": "~0.1.0"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",
     "coveralls": "~2.11.2",
     "istanbul": "~0.3.6",
-    "mapnik": "^3.5.13",
+    "mapnik": "^3.6.0",
     "jshint": "^2.6.3",
     "pbf": "^1.3.2",
     "tape": "~3.5.0",


### PR DESCRIPTION
After merge:
- [ ] Run `npm publish --access=public` to publish the first namespaced version
- [ ] Run `npm deprecate vector-tile "This module has moved: please install @mapbox/vector-tile instead"`

/cc @mourner @jfirebaugh 