### PR TITLE
Use namespaced package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ zlib.gunzip(data, function(err, buffer) {
 
 To install:
 
-    npm install vector-tile
+    npm install @mapbox/vector-tile
 
 
 ## API Reference


### PR DESCRIPTION
Based on instructions from NPM:

$ npm install vector-tile
npm WARN deprecated vector-tile@1.3.0: This module has moved: please install @mapbox/vector-tile instead
npm WARN deprecated point-geometry@0.0.0: This module has moved: please install @mapbox/point-geometry instead
mvt-compare@1.0.0 /home/evan/knock/mvt-compare
└─┬ vector-tile@1.3.0 
  └── point-geometry@0.0.0 

$ npm install @mapbox/vector-tile
mvt-compare@1.0.0 /home/evan/knock/mvt-compare
└─┬ @mapbox/vector-tile@1.3.0 
  └── @mapbox/point-geometry@0.1.0