### PR TITLE
Add initial support for VT3 draft spec [WIP]

### DIFF
--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -4,17 +4,21 @@ var Point = require('@mapbox/point-geometry');
 
 module.exports = VectorTileFeature;
 
-function VectorTileFeature(pbf, end, extent, keys, values) {
+function VectorTileFeature(pbf, end, layer) {
     // Public
     this.properties = {};
-    this.extent = extent;
+    this.extent = layer.extent;
     this.type = 0;
 
     // Private
     this._pbf = pbf;
+    this._layer = layer;
     this._geometry = -1;
-    this._keys = keys;
-    this._values = values;
+
+    // VT3
+    this._geometricAttributes = -1;
+    this._elevation = -1;
+    this._splineKnots = -1;
 
     pbf.readFields(readFeature, this, end);
 }
@@ -24,14 +28,23 @@ function readFeature(tag, feature, pbf) {
     else if (tag == 2) readTag(pbf, feature);
     else if (tag == 3) feature.type = pbf.readVarint();
     else if (tag == 4) feature._geometry = pbf.pos;
+
+    // VT3 fields
+    else if (tag == 5) readTag(pbf, feature, true);
+    else if (tag == 6) feature._geometricAttributes = pbf.pos;
+    else if (tag == 7) feature._elevation = pbf.pos;
+    else if (tag == 8) feature._splineKnots = pbf.pos;
+    else if (tag == 9) feature._splineDegree = pbf.readVarint();
+    else if (tag == 10) feature.id = pbf.readString();
 }
 
-function readTag(pbf, feature) {
+function readTag(pbf, feature, isVT3) {
     var end = pbf.readVarint() + pbf.pos;
+    var layer = feature._layer;
 
     while (pbf.pos < end) {
-        var key = feature._keys[pbf.readVarint()],
-            value = feature._values[pbf.readVarint()];
+        var key = layer._keys[pbf.readVarint()];
+        var value = isVT3 ? layer._readAttribute(pbf) : layer._values[pbf.readVarint()];
         feature.properties[key] = value;
     }
 }
@@ -85,6 +98,59 @@ VectorTileFeature.prototype.loadGeometry = function() {
     if (line) lines.push(line);
 
     return lines;
+};
+
+// TODO reorganize with nesting that follows geometry nesting
+VectorTileFeature.prototype.loadGeometricAttributes = function() {
+    if (this._geometricAttributes === -1) return null;
+
+    var pbf = this._pbf;
+    pbf.pos = this._geometricAttributes;
+
+    var end = pbf.readVarint() + pbf.pos;
+    var attributes = {};
+
+    while (pbf.pos < end) {
+        var key = this._layer._keys[pbf.readVarint()];
+        var value = this._layer._readAttribute(pbf);
+        attributes[key] = value;
+    }
+
+    return attributes;
+};
+
+// TODO: embed into loadGeometry with nesting
+VectorTileFeature.prototype.loadElevation = function() {
+    if (this._elevation === -1) return null;
+
+    var pbf = this._pbf;
+    pbf.pos = this._elevation;
+
+    var end = pbf.readVarint() + pbf.pos;
+    var elevation = [];
+    var value = 0;
+
+    while (pbf.pos < end) {
+        value += pbf.readSVarint();
+        elevation.push(this._layer._elevationScaling.scale(value));
+    }
+
+    return elevation;
+};
+
+VectorTileFeature.prototype.loadSplineKnots = function() {
+    if (this._splineKnots === -1) return null;
+
+    var pbf = this._pbf;
+    pbf.pos = this._splineKnots;
+
+    var end = pbf.readVarint() + pbf.pos;
+    var knots = [];
+
+    while (pbf.pos < end) {
+        knots.push(this._layer._readAttribute(pbf));
+    }
+    return knots;
 };
 
 VectorTileFeature.prototype.bbox = function() {

--- a/lib/vectortilelayer.js
+++ b/lib/vectortilelayer.js
@@ -17,6 +17,19 @@ function VectorTileLayer(pbf, end) {
     this._values = [];
     this._features = [];
 
+    // VT3-specific
+    this.tileX = null;
+    this.tileY = null;
+    this.tileZ = null;
+
+    this._stringValues = [];
+    this._floatValues = [];
+    this._doubleValues = [];
+    this._intValues = [];
+
+    this._elevationScaling = new Scaling();
+    this._attributeScalings = [];
+
     pbf.readFields(readLayer, this, end);
 
     this.length = this._features.length;
@@ -25,10 +38,21 @@ function VectorTileLayer(pbf, end) {
 function readLayer(tag, layer, pbf) {
     if (tag === 15) layer.version = pbf.readVarint();
     else if (tag === 1) layer.name = pbf.readString();
-    else if (tag === 5) layer.extent = pbf.readVarint();
     else if (tag === 2) layer._features.push(pbf.pos);
     else if (tag === 3) layer._keys.push(pbf.readString());
     else if (tag === 4) layer._values.push(readValueMessage(pbf));
+    else if (tag === 5) layer.extent = pbf.readVarint();
+
+    // VT3 fields
+    else if (tag === 6) layer._stringValues.push(pbf.readString());
+    else if (tag === 7) layer._floatValues.push(pbf.readFloat());
+    else if (tag === 8) layer._doubleValues.push(pbf.readDouble());
+    else if (tag === 9) layer._intValues.push(pbf.readFixed());
+    else if (tag === 10) pbf.readMessage(readScaling, layer._elevationScaling);
+    else if (tag === 11) layer._attributeScalings.push(pbf.readMessage(readScaling, new Scaling()));
+    else if (tag === 12) layer.tileX = pbf.readVarint();
+    else if (tag === 13) layer.tileY = pbf.readVarint();
+    else if (tag === 14) layer.tileZ = pbf.readVarint();
 }
 
 function readValueMessage(pbf) {
@@ -50,6 +74,12 @@ function readValueMessage(pbf) {
     return value;
 }
 
+function readScaling(tag, scaling, pbf) {
+    if (tag === 1) scaling.offset = pbf.readSVarint();
+    else if (tag === 2) scaling.multiplier = pbf.readDouble();
+    else if (tag === 3) scaling.base = pbf.readDouble();
+}
+
 // return feature `i` from this layer as a `VectorTileFeature`
 VectorTileLayer.prototype.feature = function(i) {
     if (i < 0 || i >= this._features.length) throw new Error('feature index out of bounds');
@@ -57,5 +87,67 @@ VectorTileLayer.prototype.feature = function(i) {
     this._pbf.pos = this._features[i];
 
     var end = this._pbf.readVarint() + this._pbf.pos;
-    return new VectorTileFeature(this._pbf, end, this.extent, this._keys, this._values);
+    return new VectorTileFeature(this._pbf, end, this);
+};
+
+// Decode VT3 attributes (complex values)
+VectorTileLayer.prototype._readAttribute = function(pbf) {
+    var complexValue = pbf.readVarint();
+    var type = complexValue & 0x0f;
+    var parameter = complexValue >> 4;
+
+    switch (type) {
+    case 0: return this._stringValues[parameter];
+    case 1: return this._floatValues[parameter];
+    case 2: return this._doubleValues[parameter];
+    case 3: return this._intValues[parameter];
+    case 4: return decodeZigzag(this._intValues[parameter]);
+    case 5: return parameter;
+    case 6: return decodeZigzag(parameter);
+    case 7: return parameter === 0 ? null : Boolean(parameter >> 1);
+    case 8: // list
+        var values = [];
+        for (var i = 0; i < parameter; i++) {
+            values.push(this._readAttribute(pbf));
+        }
+        return values;
+    case 9: // map
+        var properties = {};
+        for (i = 0; i < parameter; i++) {
+            var keyIndex = pbf.readVarint();
+            properties[this._keys[keyIndex]] = this._readAttribute(pbf);
+        }
+        return properties;
+    case 10: // delta-encoded list
+        values = [];
+        var scaling = this._attributeScalings[pbf.readVarint()];
+        var value = 0;
+        for (i = 0; i < parameter; i++) {
+            var encoding = pbf.readVarint();
+            if (encoding === 0) {
+                values.push(null);
+            } else {
+                value += decodeZigzag(encoding - 1);
+                values.push(scaling.scale(value));
+            }
+        }
+        return values;
+    }
+
+    throw new Error('Unrecognized complex value type: ' + type);
+};
+
+function decodeZigzag(value) {
+    return (value % 2 === 1 ? -value - 1 : value) >> 1;
+}
+
+// VT3 Scaling
+function Scaling(offset, multiplier, base) {
+    this.offset = offset || 0;
+    this.multiplier = multiplier || 1;
+    this.base = base || 0;
+}
+
+Scaling.prototype.scale = function(value) {
+    return this.base + this.multiplier * (value + this.offset);
 };

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -191,7 +191,7 @@ test('VectorTileLayer', function(t) {
 });
 
 test('VectorTileFeature', function(t) {
-    var emptyFeature = new VectorTileFeature(new Protobuf(new Buffer([])));
+    var emptyFeature = new VectorTileFeature(new Protobuf(new Buffer([])), undefined, {});
     t.ok(emptyFeature, 'can be created with no values');
     t.ok(Array.isArray(VectorTileFeature.types));
     t.deepEqual(VectorTileFeature.types, ['Unknown', 'Point', 'LineString', 'Polygon']);


### PR DESCRIPTION
Adds initial support for [Vector Tile 3 specification draft](https://github.com/mapbox/vector-tile-spec/tree/v3.0-development/3.0). To do:

- [ ] Lots of test coverage
- [ ] Add nesting for geometric attributes
- [ ] Decode elevation in `loadGeometry`, embedding it in Point objects instead of a separate array
- [ ] Add lots of assertions for the new fields for stricter validation against the spec.

cc @flippmoke @ericfischer 