### PR TITLE
v3: Upgrade to pbf v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # vector-tile
 
-This library reads [Mapbox Vector Tiles](https://github.com/mapbox/vector-tile-spec) and allows access to the layers and features.
+This library reads [Mapbox Vector Tiles](https://github.com/mapbox/vector-tile-spec) and allows access to the layers and features. Depends on [pbf](https://github.com/mapbox/pbf) v5+.
 
 ## Example
 
 ```js
 import {VectorTile} from '@mapbox/vector-tile';
-import Protobuf from 'pbf';
+import {PbfReader} from 'pbf';
 
-const tile = new VectorTile(new Protobuf(data));
+const tile = new VectorTile(new PbfReader(data));
 
 // Contains a map of all layers
 tile.layers;
@@ -28,11 +28,11 @@ zlib module would be:
 
 ```js
 import {VectorTile} from '@mapbox/vector-tile';
-import Protobuf from 'pbf';
+import {PbfReader} from 'pbf';
 import {gunzipSync} from 'zlib';
 
 const buffer = gunzipSync(data);
-const tile = new VectorTile(new Protobuf(buffer));
+const tile = new VectorTile(new PbfReader(buffer));
 ```
 
 ## Install
@@ -50,8 +50,8 @@ An object that parses vector tile data and makes it readable.
 
 #### Constructor
 
-- **new VectorTile(protobuf[, end])** &mdash;
-  parses the vector tile data contained in the given [Protobuf](https://github.com/mapbox/pbf) object,
+- **new VectorTile(pbf[, end])** &mdash;
+  parses the vector tile data contained in the given [PbfReader](https://github.com/mapbox/pbf) object,
   saving resulting layers in the created object as a `layers` property. Optionally accepts end index.
 
 #### Properties

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 
 import Point from '@mapbox/point-geometry';
 
-/** @import Pbf from 'pbf' */
+/** @import {PbfReader} from 'pbf' */
 /** @import {Feature} from 'geojson' */
 
 export class VectorTileFeature {
     /**
-     * @param {Pbf} pbf
+     * @param {PbfReader} pbf
      * @param {number} end
      * @param {number} extent
      * @param {string[]} keys
@@ -269,7 +269,7 @@ function signedArea(ring) {
 
 export class VectorTileLayer {
     /**
-     * @param {Pbf} pbf
+     * @param {PbfReader} pbf
      * @param {number} [end]
      */
     constructor(pbf, end) {
@@ -325,7 +325,7 @@ export class VectorTileLayer {
 }
 
 /**
- * @param {Pbf} pbf
+ * @param {PbfReader} pbf
  */
 function readValueMessage(pbf) {
     let value = null;
@@ -337,7 +337,7 @@ function readValueMessage(pbf) {
             tag === 10 ? pbf.readString() :
             tag === 21 ? pbf.readFloat() :
             tag === 25 ? pbf.readDouble() :
-            tag === 32 ? pbf.readVarint64() :
+            tag === 32 ? pbf.readVarint(true) :
             tag === 40 ? pbf.readVarint() :
             tag === 48 ? pbf.readSVarint() :
             tag === 56 ? pbf.readBoolean() :
@@ -352,7 +352,7 @@ function readValueMessage(pbf) {
 
 export class VectorTile {
     /**
-     * @param {Pbf} pbf
+     * @param {PbfReader} pbf
      * @param {number} [end]
      */
     constructor(pbf, end = pbf.length) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vector-tile",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vector-tile",
-      "version": "2.0.5",
+      "version": "3.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.2"
+        "pbf": "^5.0.0"
       },
       "devDependencies": {
         "benchmark": "^2.1.4",
@@ -913,9 +913,9 @@
       }
     },
     "node_modules/pbf": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
-      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.0.0.tgz",
+      "integrity": "sha512-HFx0doswd4f/TcMbK4x8ZpnRdjdYnqxvpY+gYfxGA0hZwSAwtasDugdm8RvqjHAFmEXtdCZBEywpDwuMdwgBFg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": {
     "url": "git+https://github.com/mapbox/vector-tile-js.git"
   },
-  "version": "2.0.5",
+  "version": "3.0.0",
   "type": "module",
   "exports": "./index.js",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@mapbox/point-geometry": "~1.1.0",
     "@types/geojson": "^7946.0.16",
-    "pbf": "^4.0.2"
+    "pbf": "^5.0.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -1,13 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs';
-import Protobuf from 'pbf';
+import {PbfReader, PbfWriter} from 'pbf';
 import {VectorTile, VectorTileLayer, VectorTileFeature} from '../index.js';
 import Point from '@mapbox/point-geometry';
 
 function getFixtureTile(name) {
     const data = fs.readFileSync(new URL(`fixtures/${name}.pbf`, import.meta.url));
-    return new VectorTile(new Protobuf(data));
+    return new VectorTile(new PbfReader(data));
 }
 
 const tile = getFixtureTile('14-8801-5371.vector');
@@ -175,12 +175,12 @@ test('toGeoJSON', () => {
 });
 
 test('VectorTileLayer', () => {
-    const emptyLayer = new VectorTileLayer(new Protobuf(Buffer.alloc(0)));
+    const emptyLayer = new VectorTileLayer(new PbfReader(Buffer.alloc(0)));
     assert.ok(emptyLayer, 'can be created with no values');
 });
 
 test('VectorTileFeature', () => {
-    const emptyFeature = new VectorTileFeature(new Protobuf(Buffer.alloc(0)));
+    const emptyFeature = new VectorTileFeature(new PbfReader(Buffer.alloc(0)));
     assert.ok(emptyFeature, 'can be created with no values');
     assert.ok(Array.isArray(VectorTileFeature.types));
     assert.deepEqual(VectorTileFeature.types, ['Unknown', 'Point', 'LineString', 'Polygon']);
@@ -210,7 +210,7 @@ test('skips unknown fields at every nesting level', () => {
     // Build a tile that has an unknown field on the Tile, Layer, Feature, and
     // Value messages. Inlined readers must skip them (not infinite-loop) and
     // still surface the known data correctly.
-    const pbf = new Protobuf();
+    const pbf = new PbfWriter();
 
     pbf.writeStringField(99, 'unknown-tile-field');
     pbf.writeMessage(3, (_, p) => { // Tile.layers
@@ -232,7 +232,7 @@ test('skips unknown fields at every nesting level', () => {
         p.writeVarintField(5, 4096);
     }, null);
 
-    const tile = new VectorTile(new Protobuf(pbf.finish()));
+    const tile = new VectorTile(new PbfReader(pbf.finish()));
     const layer = tile.layers.layer;
     assert.ok(layer);
     assert.equal(layer.length, 1);
@@ -244,7 +244,7 @@ test('skips unknown fields at every nesting level', () => {
 test('Value message with only an unknown field throws rather than looping', () => {
     // Regression: readValueMessage used to infinite-loop on a Value containing
     // no known tag (no value set + pos didn't advance).
-    const pbf = new Protobuf();
+    const pbf = new PbfWriter();
     pbf.writeMessage(3, (_, p) => {
         p.writeStringField(1, 'layer');
         p.writeStringField(3, 'k');
@@ -260,7 +260,7 @@ test('Value message with only an unknown field throws rather than looping', () =
     }, null);
 
     const buf = pbf.finish();
-    assert.throws(() => new VectorTile(new Protobuf(buf)), /unknown feature value/);
+    assert.throws(() => new VectorTile(new PbfReader(buf)), /unknown feature value/);
 });
 
 test('skips zero-count geometry commands', () => {
@@ -270,7 +270,7 @@ test('skips zero-count geometry commands', () => {
     // The leading zero-count command must be skipped, not break the loop
     // (which would lose the real MoveTo) and not be executed (which would
     // consume the next command's bytes as a coordinate pair).
-    const pbf = new Protobuf();
+    const pbf = new PbfWriter();
     pbf.writeMessage(3, (_, p) => {
         p.writeStringField(1, 'layer');
         p.writeMessage(2, (_, p) => {
@@ -281,14 +281,14 @@ test('skips zero-count geometry commands', () => {
         p.writeVarintField(5, 4096);
     }, null);
 
-    const tile = new VectorTile(new Protobuf(pbf.finish()));
+    const tile = new VectorTile(new PbfReader(pbf.finish()));
     const feature = tile.layers.layer.feature(0);
     assert.deepEqual(feature.loadGeometry(), [[new Point(3, 4)]]);
     assert.deepEqual(feature.bbox(), [3, 4, 3, 4]);
 });
 
 test('throws a clear error for a feature with no geometry (issue #39)', () => {
-    const pbf = new Protobuf();
+    const pbf = new PbfWriter();
     pbf.writeMessage(3, (_, p) => {
         p.writeStringField(1, 'layer');
         p.writeMessage(2, (_, p) => {
@@ -299,7 +299,7 @@ test('throws a clear error for a feature with no geometry (issue #39)', () => {
         p.writeVarintField(5, 4096);
     }, null);
 
-    const tile = new VectorTile(new Protobuf(pbf.finish()));
+    const tile = new VectorTile(new PbfReader(pbf.finish()));
     const feature = tile.layers.layer.feature(0);
     assert.throws(() => feature.loadGeometry(), /feature has no geometry/);
     assert.throws(() => feature.bbox(), /feature has no geometry/);
@@ -309,7 +309,7 @@ test('throws a clear error for a feature with no geometry (issue #39)', () => {
 test('does not mutate prototypes via a "__proto__" layer name or property key', () => {
     // Hand-build a minimal MVT tile containing a layer named "__proto__"
     // with one feature whose properties include a "__proto__" key.
-    const pbf = new Protobuf();
+    const pbf = new PbfWriter();
 
     pbf.writeMessage(3, (_, p) => { // Tile.layers
         p.writeVarintField(15, 2);                  // version
@@ -327,7 +327,7 @@ test('does not mutate prototypes via a "__proto__" layer name or property key', 
         p.writeVarintField(5, 4096);                 // extent
     }, null);
 
-    const tile = new VectorTile(new Protobuf(pbf.finish()));
+    const tile = new VectorTile(new PbfReader(pbf.finish()));
 
     // tile.layers must keep a null prototype — i.e. its prototype wasn't
     // hijacked by `layers["__proto__"] = layer`.


### PR DESCRIPTION
Updates `vector-tile-js` to work with Pbf v5, which introduced a breaking change (splitting `Pbf` class into `PbfReader` and `PbfWriter`): https://github.com/mapbox/pbf/releases/tag/v5.0.0